### PR TITLE
fix: revert react version bump due to the lack of support from enzyme

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prismjs": "^1.14.0",
     "react": "16",
     "react-bootstrap": "^0.32.1",
-    "react-dom": ">=16.0.1",
+    "react-dom": "16",
     "react-freecodecamp-search": "^2.0.2",
     "react-ga": "^2.5.2",
     "react-helmet": "^5.2.0",


### PR DESCRIPTION
## Description
This reverts commit e8189a1b569ef91426b79d5f9a899b9e3c2fe33f.

## Note
- Do not merge until Netlify build is tested