### PR TITLE
fix test in Advanced Node and Express - Communicate by Emitting.

### DIFF
--- a/curriculum/challenges/06-information-security-and-quality-assurance/advanced-node-and-express.json
+++ b/curriculum/challenges/06-information-security-and-quality-assurance/advanced-node-and-express.json
@@ -497,7 +497,7 @@
         },
         {
           "text": "客户端应监听 'user count' 事件。",
-          "testString": "getUserInput => $.get(getUserInput('url')+ '/public/client.js') .then(data => { assert.match(data, /socket.on.*('|\")user count('|\")/gi, '客户端应通过 socket 连接到服务端，并监听 'user count' 事件。'); }, xhr => { throw new Error(xhr.statusText); })"
+          "testString": "getUserInput => $.get(getUserInput('url')+ '/public/client.js') .then(data => { assert.match(data, /socket.on.*('|\")user count('|\")/gi, '客户端应通过 socket 连接到服务端，并监听 \"user count\" 事件。'); }, xhr => { throw new Error(xhr.statusText); })"
         }
       ],
       "solutions": [],


### PR DESCRIPTION
Previous test will get a wrong like this:"missing ) after argument list",this is because of the single quotes around
```
并监听 'user count' 事件。
```
more info in https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list